### PR TITLE
Fix archived approval request handling: proper API fetch, status disp…

### DIFF
--- a/pages/api/approval-requests/[id].ts
+++ b/pages/api/approval-requests/[id].ts
@@ -683,7 +683,7 @@ async function updateApprovalRequest(
       // Handle archiving (staff only)
       if (isArchived !== undefined && !isClientPortal) {
         const query = `
-          UPDATE client_approval_requests SET is_archived = ? WHERE request_id = ?
+          UPDATE client_approval_requests SET is_archived = ?, updated_at = NOW() WHERE request_id = ?
         `;
         await connection.query(query, [isArchived ? 1 : 0, requestId]);
         console.log(`Archive status updated for request ${requestId}`);

--- a/pages/api/approval-requests/index.ts
+++ b/pages/api/approval-requests/index.ts
@@ -195,11 +195,11 @@ async function getApprovalRequests(req: NextApiRequest, res: NextApiResponse, us
     // Order by created_at
     query += ' ORDER BY ar.created_at DESC';
 
-    console.log('SQL Query:', query);
-    console.log('Query params:', queryParams);
+    // console.log('SQL Query:', query);
+    // console.log('Query params:', queryParams);
 
     const [rows] = await pool.query(query, queryParams);
-    console.log('Query returned', (rows as any[]).length, 'results');
+    // console.log('Query returned', (rows as any[]).length, 'results');
 
     // If we're filtering by user_id and got zero results, try a direct query approach
     if (user_id && user_id !== 'all' && (rows as any[]).length === 0) {

--- a/pages/client-approval/index.tsx
+++ b/pages/client-approval/index.tsx
@@ -127,6 +127,9 @@ export default function ClientApprovalPage() {
     }
   }, [tabValue]);
 
+  // Helper to determine if archived tab is selected
+  const isArchivedTab = tabValue === 2;
+
   // Fetch all approval requests
   const fetchApprovalRequests = async () => {
     setLoading(true);
@@ -158,6 +161,11 @@ export default function ClientApprovalPage() {
       // Add status filter if selected
       if (statusFilter !== 'all') {
         params.append('status', statusFilter);
+      }
+
+      // Add include_archived if archived tab is selected
+      if (isArchivedTab) {
+        params.append('include_archived', 'true');
       }
 
       if (params.toString()) {
@@ -291,11 +299,20 @@ export default function ClientApprovalPage() {
   const filteredRequests = getFilteredRequests();
 
   // Generate status chip with appropriate color
-  const getStatusChip = (status: string) => {
+  const getStatusChip = (request: ApprovalRequest) => {
+    if (request.is_archived) {
+      return (
+        <Chip
+          label="Archived"
+          color="default"
+          size="small"
+          sx={{ bgcolor: 'grey.400', color: 'white' }}
+        />
+      );
+    }
     let color: 'default' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning' =
       'default';
-
-    switch (status) {
+    switch (request.status) {
       case 'pending':
         color = 'warning';
         break;
@@ -306,9 +323,12 @@ export default function ClientApprovalPage() {
         color = 'error';
         break;
     }
-
     return (
-      <Chip label={status.charAt(0).toUpperCase() + status.slice(1)} color={color} size="small" />
+      <Chip
+        label={request.status.charAt(0).toUpperCase() + request.status.slice(1)}
+        color={color}
+        size="small"
+      />
     );
   };
 
@@ -372,6 +392,11 @@ export default function ClientApprovalPage() {
       // Add status filter if selected
       if (statusFilter !== 'all') {
         params.append('status', statusFilter);
+      }
+
+      // Add include_archived if archived tab is selected
+      if (isArchivedTab) {
+        params.append('include_archived', 'true');
       }
 
       if (params.toString()) {
@@ -487,6 +512,11 @@ export default function ClientApprovalPage() {
         params.append('status', statusFilter);
       }
 
+      // Add include_archived if archived tab is selected
+      if (isArchivedTab) {
+        params.append('include_archived', 'true');
+      }
+
       if (params.toString()) {
         url += `?${params.toString()}`;
       }
@@ -555,6 +585,11 @@ export default function ClientApprovalPage() {
       // Add status filter if selected - use passed value
       if (currentStatusFilter !== 'all') {
         params.append('status', currentStatusFilter);
+      }
+
+      // Add include_archived if archived tab is selected
+      if (isArchivedTab) {
+        params.append('include_archived', 'true');
       }
 
       if (params.toString()) {
@@ -776,7 +811,7 @@ export default function ClientApprovalPage() {
                         <Typography variant="h6" noWrap sx={{ maxWidth: '70%' }}>
                           {request.title}
                         </Typography>
-                        {getStatusChip(request.status)}
+                        {getStatusChip(request)}
                       </Box>
 
                       <Typography variant="body2" color="textSecondary" gutterBottom>

--- a/pages/client-approval/requests/[id].tsx
+++ b/pages/client-approval/requests/[id].tsx
@@ -399,9 +399,18 @@ export default function ApprovalRequestDetailPage() {
     setUpdatingUrl(true);
 
     try {
-      await axios.put(`/api/approval-requests/${id}`, {
-        publishedUrl: publishedUrl.trim(),
-      });
+      const headers: Record<string, string> = {};
+      if (token) {
+        headers['x-auth-token'] = token;
+      }
+
+      await axios.put(
+        `/api/approval-requests/${id}`,
+        {
+          publishedUrl: publishedUrl.trim(),
+        },
+        { headers }
+      );
 
       fetchRequestDetails();
     } catch (error) {
@@ -449,9 +458,12 @@ export default function ApprovalRequestDetailPage() {
   // Handle archiving the request
   const handleArchiveRequest = async () => {
     try {
-      await axios.put(`/api/approval-requests/${id}`, {
-        isArchived: true,
-      });
+      const headers: Record<string, string> = {};
+      if (token) {
+        headers['x-auth-token'] = token;
+      }
+
+      await axios.put(`/api/approval-requests/${id}`, { isArchived: true }, { headers });
 
       router.push('/client-approval');
     } catch (error) {


### PR DESCRIPTION
**Summary**
This PR improves the handling of archived approval requests in the client approval dashboard, ensuring correct API usage, authentication, and user interface clarity.
Key Changes

**API Authentication:**
Ensured all staff-side API calls to update approval requests (e.g., archiving, updating published URL) include the x-auth-token header for proper authentication.

**Archived Requests Tab:**
Updated the frontend to include include_archived=true in API requests when the "Archived Requests" tab is selected, so archived requests are actually fetched from the backend.

**Status Chip Display:**
Modified the status chip logic so that archived requests display an "Archived" chip with a distinct color, rather than showing as "Pending."

**Code Consistency:**
Refactored status chip rendering to use the full request object, ensuring correct status display and fixing related linter errors.
Why?
Previously, archived requests were not fetched from the backend, resulting in an empty "Archived Requests" tab.
Archived requests were visually indistinguishable from pending requests, causing confusion.
Some staff actions were failing due to missing authentication headers.

**Testing**
Switch to the "Archived Requests" tab and verify that archived requests are displayed.
Confirm that archived requests show an "Archived" status chip.
Test archiving and unarchiving requests as a staff user to ensure proper API behavior and UI updates.
